### PR TITLE
Fix conversation filtering by user

### DIFF
--- a/src/app/Repositories/Eloquent/ConversationRepository.php
+++ b/src/app/Repositories/Eloquent/ConversationRepository.php
@@ -4,7 +4,7 @@ namespace App\Repositories\Eloquent;
 
 use App\Repositories\Interfaces\ConversationRepositoryInterface;
 
-class ConversationRepository implements  ConversationRepositoryInterface
+class ConversationRepository implements ConversationRepositoryInterface
 {
     protected $model;
 
@@ -13,14 +13,19 @@ class ConversationRepository implements  ConversationRepositoryInterface
         $this->model = app()->make('App\Models\Conversation');
     }
 
-    public function getAllConversations()
+    public function getAllConversations(int $userId)
     {
-        return $this->model->get();
+        return $this->model->whereHas('users', function ($query) use ($userId) {
+            $query->where('users.id', $userId);
+        })->get();
     }
 
-    public function getConversationById(int $conversationId)
+    public function getConversationById(int $conversationId, int $userId)
     {
-        return $this->model->where('id', $conversationId)->first();
+        return $this->model->where('id', $conversationId)
+            ->whereHas('users', function ($query) use ($userId) {
+                $query->where('users.id', $userId);
+            })->first();
     }
 
     public function createConversation(array $data)
@@ -30,7 +35,7 @@ class ConversationRepository implements  ConversationRepositoryInterface
 
     public function updateConversation(int $conversationId, array $data)
     {
-        $conversation = $this->getConversationById($conversationId);
+        $conversation = $this->model->where('id', $conversationId)->first();
         if ($conversation) {
             return $conversation->update($data);
         }
@@ -39,7 +44,7 @@ class ConversationRepository implements  ConversationRepositoryInterface
 
     public function deleteConversation(int $conversationId)
     {
-        $conversation = $this->getConversationById($conversationId);
+        $conversation = $this->model->where('id', $conversationId)->first();
         if ($conversation) {
             return $conversation->delete();
         }

--- a/src/app/Repositories/Interfaces/ConversationRepositoryInterface.php
+++ b/src/app/Repositories/Interfaces/ConversationRepositoryInterface.php
@@ -4,9 +4,15 @@ namespace App\Repositories\Interfaces;
 
 interface ConversationRepositoryInterface
 {
-    public function getAllConversations();
+    /**
+     * Get all conversations for a specific user.
+     */
+    public function getAllConversations(int $userId);
 
-    public function getConversationById(int $conversationId);
+    /**
+     * Get a conversation by id that belongs to a specific user.
+     */
+    public function getConversationById(int $conversationId, int $userId);
 
     public function createConversation(array $data);
 

--- a/src/app/Services/ConversationService.php
+++ b/src/app/Services/ConversationService.php
@@ -13,14 +13,14 @@ class ConversationService
         $this->conversationRepository = $conversationRepository;
     }
 
-    public function getAllConversations()
+    public function getAllConversations(int $userId)
     {
-        return $this->conversationRepository->getAllConversations();
+        return $this->conversationRepository->getAllConversations($userId);
     }
 
-    public function getConversationById(int $conversationId)
+    public function getConversationById(int $conversationId, int $userId)
     {
-        return $this->conversationRepository->getConversationById($conversationId);
+        return $this->conversationRepository->getConversationById($conversationId, $userId);
     }
 
     public function createConversation(array $data)

--- a/src/tests/Unit/ConversationServiceTest.php
+++ b/src/tests/Unit/ConversationServiceTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Repositories\Interfaces\ConversationRepositoryInterface;
+use App\Services\ConversationService;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class ConversationServiceTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_get_all_conversations_passes_user_id_to_repository(): void
+    {
+        $repo = Mockery::mock(ConversationRepositoryInterface::class);
+        $service = new ConversationService($repo);
+
+        $userId = 1;
+        $expected = ['conversation1', 'conversation2'];
+
+        $repo->shouldReceive('getAllConversations')
+            ->once()
+            ->with($userId)
+            ->andReturn($expected);
+
+        $this->assertSame($expected, $service->getAllConversations($userId));
+    }
+}


### PR DESCRIPTION
## Summary
- restrict conversation fetching to the authenticated user
- implement repository methods to accept user id
- update ConversationService accordingly
- add a unit test for ConversationService

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6878ba31e970832295716362a836173e